### PR TITLE
Fixup pyinstaller build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Install required packages
         run: pip install -r requirements.txt pyinstaller
       - name: Package GUI
-        run: pyinstaller -F gui.spec
+        run: pyinstaller gui.spec
       - name: Package CLI
-        run: pyinstaller -F cli.spec
+        run: pyinstaller cli.spec
       - name: Copy Executables
         run: xcopy dist .
       - name: Upload Release
@@ -40,9 +40,9 @@ jobs:
       - name: Install required packages
         run: pip install -r requirements.txt pyinstaller
       - name: Package GUI
-        run: pyinstaller -F gui.spec
+        run: pyinstaller gui.spec
       - name: Package CLI
-        run: pyinstaller -F cli.spec
+        run: pyinstaller cli.spec
       - name: Copy Executables
         run: |
           rm -r MiitopiaRandomizer

--- a/package_release.bat
+++ b/package_release.bat
@@ -2,8 +2,8 @@ if exist dist/ rmdir /S /Q dist
 if exist Release/ rmdir /S /Q Release
 
 python -m pip install sarc pyqt6 pyinstaller
-pyinstaller -F cli.spec
-pyinstaller -F gui.spec
+pyinstaller cli.spec
+pyinstaller gui.spec
 
 mkdir Release
 xcopy /E /I /Y Input Release\Input

--- a/package_release.sh
+++ b/package_release.sh
@@ -3,8 +3,8 @@ rm -r dist
 rm -r Release
 
 pip install sarc pyqt6 pyinstaller
-pyinstaller -F cli.spec
-pyinstaller -F gui.spec
+pyinstaller cli.spec
+pyinstaller gui.spec
 
 mkdir -p Release
 cp -r Input Release


### PR DESCRIPTION
When I used pyinstaller to create the .spec files, it already stored the `--onefile` (`-F`) option in the file so passing it again in the build script(s) is (1) redundant and (2) leads to issues with Pyinstaller 5